### PR TITLE
Adapt supported Ansible and Debian releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ env:
   global:
     - "IMAGE=irap/docker-debian-ansible:stretch"
   matrix:
+    - "ANSIBLE_VERSION=2.5.0.0"
     - "ANSIBLE_VERSION=2.4.3.0"
     - "ANSIBLE_VERSION=2.3.3.0"
     - "ANSIBLE_VERSION=2.2.3.0"
-    - "ANSIBLE_VERSION=2.1.6.0"
 language: "python"
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ An Ansible role which installs and configures golang (The Go Programming Languag
 
 ## Requirements
 
-Currently this role is developed for and tested on Debian GNU/Linux (release: stretch). It is assumed to work on other Debian distributions as well.
+Currently this role is developed for and tested on Debian GNU/Linux (release: stretch).
 
 Ansible version compatibility:
 
-- __2.4.3.0__ (current version in use for development of this role)
+- __2.5.0.0__ (current version in use for development of this role)
+- 2.4.3.0
 - 2.3.3.0
 - 2.2.3.0
-- 2.1.6.0
 
 ## Example
 
@@ -50,9 +50,9 @@ Available variables are listed below, along with default values (see defaults/ma
 variable | default | notes
 -------- | ------- | -----
 `environment_file` | `/etc/profile.d/golang.sh` | `Absolute path where $GOROOT/$PATH exports are stored`
-`go_version` | `1.10` | `The version of the Go Programming Language that is going to be installed`
+`go_version` | `1.10.1` | `The version of the Go Programming Language that is going to be installed`
 `gopath` | `/opt/go` | `The $GOPATH lists places to look for Go code.`
-`supported_distro_list` | `['jessie', 'stretch']` | `A list of distribution releases this role supports`
+`supported_distro_list` | `['stretch']` | `A list of distribution releases this role supports`
 `tarball_dest` | `/tmp` | `Destination where golang's tarball is stored`
 `tarball_name` | `go{{ golang_go_version }}.linux-amd64.tar.gz` | `Naming schema of golang's tarball`
 `test_directory` | `/tmp` | `The directory where tests will be temporary stored and run in (auto cleanup)`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,9 @@
 ---
 
 golang_environment_file: "/etc/profile.d/golang.sh"
-golang_go_version: "1.10"
+golang_go_version: "1.10.1"
 golang_gopath: "/opt/go"
 golang_supported_distro_list:
-  - "jessie"
   - "stretch"
 golang_tarball_name: "go{{ golang_go_version }}.linux-amd64.tar.gz"
 golang_tarball_dest: "/tmp"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,10 +7,9 @@ galaxy_info:
   galaxy_tags:
     - "golang"
     - "Go"
-  min_ansible_version: "2.1.6.0"
+  min_ansible_version: "2.2.3.0"
   license: "MIT"
   platforms:
     - name: "Debian"
       versions:
-        - "jessie"
         - "stretch"


### PR DESCRIPTION
Deprecate Ansible 2.1.6.0 support in favour of 2.5.0.0
Deprecate Debian Jessie support
Bump golang version to 1.10.1